### PR TITLE
Use Setuptools SCM to manage release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 *.tap
 .venv/
 build/
+_version.py

--- a/devel.txt
+++ b/devel.txt
@@ -8,3 +8,4 @@ pylint
 twine
 pyOpenSSL
 readme_renderer[md]
+setuptools-scm==3.2.0

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,20 @@ with open('README.rst') as readme:
 REQUIREMENTS = open('requirements.txt').readlines()
 
 
+def local_scheme(version):
+    """
+    """
+    from setuptools_scm.version import get_local_node_and_date
+    version = get_local_node_and_date(version)
+    return '.'.join(version.split('.')[:1])
+
+
 setup(name='kiwitcms-tap-plugin',
-      version='0.2',
+      use_scm_version={
+          'write_to': 'tcms_tap_plugin/_version.py',
+          'local_scheme': local_scheme,
+      },
+      setup_requires=['setuptools_scm'],
       packages=['tcms_tap_plugin'],
       scripts=['tcms-tap-plugin'],
       description='Test Anything Protocol (TAP) plugin for '

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ REQUIREMENTS = open('requirements.txt').readlines()
 
 def local_scheme(version):
     """
+    Remove date part from local version
     """
     from setuptools_scm.version import get_local_node_and_date
     version = get_local_node_and_date(version)

--- a/tcms_tap_plugin/__init__.py
+++ b/tcms_tap_plugin/__init__.py
@@ -6,6 +6,13 @@ from tap.line import Result
 from tap.parser import Parser
 from tcms_api.plugin_helpers import Backend
 
+from pkg_resources import get_distribution, DistributionNotFound
+try:
+    __version__ = get_distribution(__name__).version
+except DistributionNotFound:
+    # package is not installed
+    pass
+
 
 class Plugin:  # pylint: disable=too-few-public-methods
     def __init__(self):


### PR DESCRIPTION
Hi @atodorov 

To manage python package versions i prefer to use SCM metadata instead of manually change version number, it's easy to forget to increase the version number

I use setuptools_scm (it's an official Python Packaging Authority tools)

to check the changes
```
python setup.py --version
0.3.dev2+g967607b
```

And now with this new version format we can have **0.3.dev2** as a product number and **g967607b** as build number ( version number can be customize)

 What do you think about these changes ?

Regards,

