### PR TITLE
Call backend.finish_test_run() when done. Fix #9

### DIFF
--- a/tcms_tap_plugin/__init__.py
+++ b/tcms_tap_plugin/__init__.py
@@ -61,6 +61,8 @@ class Plugin:  # pylint: disable=too-few-public-methods
             if progress_cb:
                 progress_cb()
 
+        self.backend.finish_test_run()
+
 
 def main(argv):
     if len(argv) < 2:


### PR DESCRIPTION
will set stop_date at the end and close the TestRun