### PR TITLE
Remove deprecated license specifier from setup.py

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,7 @@
+[metadata]
+license = GPLv3+
+license_files = LICENSE
+
 [flake8]
 max-line-length = 102
 extend-ignore = E203

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setup(
     long_description=LONG_DESCRIPTION,
     author="Kiwi TCMS",
     author_email="info@kiwitcms.org",
-    license="GPLv3+",
     url="https://github.com/kiwitcms/tap-plugin",
     install_requires=REQUIREMENTS,
     classifiers=[
@@ -42,7 +41,6 @@ setup(
         "Environment :: Console",
         "Intended Audience :: Developers",
         "Intended Audience :: System Administrators",
-        "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
         "Operating System :: POSIX",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
This PR removes the deprecated `license` argument and classifier from `setup.py` and specifies `license_files` in `setup.cfg` instead, in accordance with https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license.

This prevents the `SetuptoolsDeprecationWarning: License classifiers are deprecated.` warning during builds.